### PR TITLE
Feature/rmse

### DIFF
--- a/src/JpegHelpers/Driver.java
+++ b/src/JpegHelpers/Driver.java
@@ -4,6 +4,7 @@ import javax.imageio.ImageIO;
 import javax.swing.*;
 
 import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -19,12 +20,14 @@ public class Driver {
     JButton setPath = new JButton("Set Path");
     JButton decodeButton = new JButton("Decode (JPEG to BMP)");
     JLabel pathLabel = new JLabel("File Path:");
+    JButton calculateRMSE = new JButton("Calculate RMSE");
 
     encodeButton.setBounds(40,90,200,30);
     filePathField.setBounds(100, 50, 140, 30);
     pathLabel.setBounds(40, 50, 100, 30);
     setPath.setBounds(250, 50, 100, 30);
     decodeButton.setBounds(40, 130, 200, 30);
+    calculateRMSE.setBounds(40, 170, 200, 30);
 
 
     mainWindow.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE); // Terminate on close of window
@@ -33,6 +36,7 @@ public class Driver {
     mainWindow.add(setPath);
     mainWindow.add(decodeButton);
     mainWindow.add(pathLabel);
+    mainWindow.add(calculateRMSE);
 
     mainWindow.setSize(800,400);
     mainWindow.setLayout(null);
@@ -123,6 +127,40 @@ public class Driver {
                 fileNotFoundException.printStackTrace();
             } catch (IOException ioException) {
                 ioException.printStackTrace();
+            }
+        });
+
+        calculateRMSE.addActionListener(e -> {
+            if(path.equals("")){
+                System.out.println("Please set a path first!");
+                return;
+            }
+
+            if (path.endsWith(".bmp") || path.endsWith(".jpg")) {
+
+                String pathWithoutExtension = path.substring(0, path.length() - 4);
+                String bmpPath = pathWithoutExtension + ".bmp";
+                String jpegPath = pathWithoutExtension + ".jpg";
+
+                try{
+
+                    BufferedImage sourceImage = ImageIO.read(new File(bmpPath));
+                    BufferedImage convertedImage = ImageIO.read(new File(jpegPath));
+
+                    RootMeanSquareError rmse = new RootMeanSquareError();
+                    float[][] sourceRGB = rmse.rgbValueMerge(sourceImage);
+                    float[][] convertedRGB = rmse.rgbValueMerge(convertedImage);
+
+                    rmse.rmseCalculate(sourceRGB, convertedRGB);
+
+                } catch(Exception exception) {
+                    System.out.println("An error occurred during RMSE calculation.");
+                    System.out.println(exception.getMessage());
+                }
+
+            } else {
+                System.out.println("Please set a valid path first!");
+                System.out.println("it should be a valid file and in BMP or JPEG format.");
             }
         });
     }

--- a/src/JpegHelpers/JpegEncoder.java
+++ b/src/JpegHelpers/JpegEncoder.java
@@ -17,7 +17,6 @@ public class JpegEncoder {
     int dataStartPoint;
     BufferedOutputStream outputStream;
     DCT dct = new DCT();
-    ArrayList<Double> RMSEPool = new ArrayList<>();
 
     public static int[] jpegNaturalOrder = { 0, 1, 8, 16, 9, 2, 3, 10, 17, 24, 32, 25, 18, 11, 4, 5,
             12, 19, 26, 33, 40, 48, 41, 34, 27, 20, 13, 6, 7, 14, 21, 28, 35, 42, 49, 56, 57, 50, 43, 36,
@@ -105,7 +104,6 @@ public class JpegEncoder {
         // End Marker
         byte[] endOfImage = { (byte)0xFF, (byte)0xD9 };
         WriteMarker(endOfImage, outputStream);
-        //System.out.println("RMSE of DCTs: " + MeanAverage(RMSEPool));
 
         try{
             outputStream.flush();
@@ -420,35 +418,6 @@ public class JpegEncoder {
         }
         imageWriter.drawImage(dctImage, xOffset, yOffset, null);
     }
-    // TODO: Revamp RMSE Func to compare original values versus after decoding values
-//    public double RootMeanSquareError(float[][] observed, int[] forecast){
-//        // also do this for all 3 channels, avg those values and then do sqrt
-//        // rmse can be summarized as sqrt(mean((forecast - observed)^2))
-//        // observed is [8][8], forecast is [8*8] (so [64])
-//        double addSubResults = 0.0;
-//        for(int i = 0; i < 8; i++)
-//        {
-//            for(int j = 0; j < 8; j++)
-//            {
-//                //addSubResults += Math.pow((forecast[(8*i) + j] - observed[i][j]), 2);
-//                addSubResults += Math.abs(forecast[(8*i) + j] - observed[i][j]);
-//                // do this for whole image instead of on 8x8 blocks at a time
-//            }
-//        }
-//        addSubResults = addSubResults / 64.0;
-//        return addSubResults; // math.sqrt should be here
-//    }
 
     //TODO: i really need to organize this code better lol, there is absolutely no reason for it to be over 450 lines
-//    public double MeanAverage(ArrayList<Double> RMSEPool){
-//        System.out.println("Calculating Mean Average");
-//        System.out.println("RMSE Pool size: " + RMSEPool.size());
-//        System.out.println("Highest RMSE Value: " + Collections.max(RMSEPool));
-//        System.out.println("Lowest RMSE Value: " + Collections.min(RMSEPool));
-//        double sum = 0;
-//        for(int i = 0; i < RMSEPool.size(); i++){
-//            sum += RMSEPool.get(i);
-//        }
-//        return sum / RMSEPool.size();
-//    }
 }

--- a/src/JpegHelpers/RootMeanSquareError.java
+++ b/src/JpegHelpers/RootMeanSquareError.java
@@ -1,0 +1,22 @@
+package JpegHelpers;
+
+public class RootMeanSquareError {
+    // TODO: Revamp RMSE Func to compare original values versus after encoding values
+//    public double RootMeanSquareError(float[][] observed, int[] forecast){
+//        // also do this for all 3 channels, avg those values and then do sqrt
+//        // rmse can be summarized as sqrt(mean((forecast - observed)^2))
+//        // observed is [8][8], forecast is [8*8] (so [64])
+//        double addSubResults = 0.0;
+//        for(int i = 0; i < 8; i++)
+//        {
+//            for(int j = 0; j < 8; j++)
+//            {
+//                //addSubResults += Math.pow((forecast[(8*i) + j] - observed[i][j]), 2);
+//                addSubResults += Math.abs(forecast[(8*i) + j] - observed[i][j]);
+//                // do this for whole image instead of on 8x8 blocks at a time
+//            }
+//        }
+//        addSubResults = addSubResults / 64.0;
+//        return addSubResults; // math.sqrt should be here
+//    }
+}

--- a/src/JpegHelpers/RootMeanSquareError.java
+++ b/src/JpegHelpers/RootMeanSquareError.java
@@ -23,18 +23,21 @@ public class RootMeanSquareError {
     }
 
     // TODO: Revamp RMSE Func to compare original values versus after encoding values
-    public double rmseCalculate(float[][] observed, float[][] forecast){
+    public void rmseCalculate(float[][] observed, float[][] forecast){
+        int runcount = 0;
         // also do this for all 3 channels, avg those values and then do sqrt
         // rmse can be summarized as sqrt(mean((forecast - observed)^2))
         double addSubResults = 0.0;
-        for(int i = 0; i < 8; i++)
+        for(int i = 0; i < observed.length; i++)
         {
-            for(int j = 0; j < 8; j++)
+            for(int j = 0; j < observed[0].length; j++)
             {
+                runcount++;
                 addSubResults += Math.pow((forecast[i][j] - observed[i][j]), 2);
             }
         }
-        addSubResults = addSubResults / (observed.length * observed[0].length); //
-        return Math.sqrt(addSubResults);
+        addSubResults = addSubResults / (observed.length * observed[0].length);
+        System.out.println("Calculations based on " + runcount + " values.");
+        System.out.println("Final RMSE is calculated to be " + Math.sqrt(addSubResults));
     }
 }

--- a/src/JpegHelpers/RootMeanSquareError.java
+++ b/src/JpegHelpers/RootMeanSquareError.java
@@ -22,7 +22,6 @@ public class RootMeanSquareError {
         return rgbValues;
     }
 
-    // TODO: Revamp RMSE Func to compare original values versus after encoding values
     public void rmseCalculate(float[][] observed, float[][] forecast){
         int runcount = 0;
         // also do this for all 3 channels, avg those values and then do sqrt
@@ -39,5 +38,23 @@ public class RootMeanSquareError {
         addSubResults = addSubResults / (observed.length * observed[0].length);
         System.out.println("Calculations based on " + runcount + " values.");
         System.out.println("Final RMSE is calculated to be " + Math.sqrt(addSubResults));
+    }
+
+    public void mseCalculate(float[][] observed, float[][] forecast){
+        // similar to rmse, but without the sqrt
+        double addSubResults = 0.0;
+        int runcount = 0;
+        for(int i = 0; i < observed.length; i++)
+        {
+            for(int j = 0; j < observed[0].length; j++)
+            {
+                runcount++;
+                addSubResults += Math.pow((forecast[i][j] - observed[i][j]), 2);
+            }
+        }
+
+        addSubResults = addSubResults / (observed.length * observed[0].length);
+        System.out.println("Calculations based on " + runcount + " values.");
+        System.out.println("Final MSE is calculated to be " + addSubResults);
     }
 }

--- a/src/JpegHelpers/RootMeanSquareError.java
+++ b/src/JpegHelpers/RootMeanSquareError.java
@@ -1,22 +1,40 @@
 package JpegHelpers;
 
+import java.awt.image.BufferedImage;
+
 public class RootMeanSquareError {
+
+    public float[][] rgbValueMerge(BufferedImage imageInput){
+
+        int width = imageInput.getWidth();
+        int height = imageInput.getHeight();
+
+        float[][] rgbValues = new float[width][height];
+
+        for(int i = 0; i < width; i++){
+            for(int j = 0; j < height; j++){
+                int rawValue = imageInput.getRGB(i, j);
+                rgbValues[i][j] = (float) (
+                        (rawValue & 0xff) + ((rawValue & 0xff00) >> 8) + ((rawValue & 0xff0000) >> 16)
+                ) / 3;
+            }
+        }
+        return rgbValues;
+    }
+
     // TODO: Revamp RMSE Func to compare original values versus after encoding values
-//    public double RootMeanSquareError(float[][] observed, int[] forecast){
-//        // also do this for all 3 channels, avg those values and then do sqrt
-//        // rmse can be summarized as sqrt(mean((forecast - observed)^2))
-//        // observed is [8][8], forecast is [8*8] (so [64])
-//        double addSubResults = 0.0;
-//        for(int i = 0; i < 8; i++)
-//        {
-//            for(int j = 0; j < 8; j++)
-//            {
-//                //addSubResults += Math.pow((forecast[(8*i) + j] - observed[i][j]), 2);
-//                addSubResults += Math.abs(forecast[(8*i) + j] - observed[i][j]);
-//                // do this for whole image instead of on 8x8 blocks at a time
-//            }
-//        }
-//        addSubResults = addSubResults / 64.0;
-//        return addSubResults; // math.sqrt should be here
-//    }
+    public double rmseCalculate(float[][] observed, float[][] forecast){
+        // also do this for all 3 channels, avg those values and then do sqrt
+        // rmse can be summarized as sqrt(mean((forecast - observed)^2))
+        double addSubResults = 0.0;
+        for(int i = 0; i < 8; i++)
+        {
+            for(int j = 0; j < 8; j++)
+            {
+                addSubResults += Math.pow((forecast[i][j] - observed[i][j]), 2);
+            }
+        }
+        addSubResults = addSubResults / (observed.length * observed[0].length); //
+        return Math.sqrt(addSubResults);
+    }
 }


### PR DESCRIPTION
Complete proper Root Mean Square Error / Mean Square Error calculations - this necessitated creating its own class, as it is not sufficient to calculate DCT values prior to transformation and post transformation. and get the average of each 8x8 block parsed. Instead, this aims to look at the source BMP image and compare it against the JPEG image to get an accurate representation of losses associated with transformation of the image. Values now fall into a much more reasonable range which is generally close to 0. 

Some of the new functions include rgbValueMerge(), which takes a BufferedImage as its argument in order to merge each pixels individual RGB color value through usage of bitshifting, as the RGB value itself from getRGB() inner function has 24 bits of data - we want to get each individual channel and average them (8 x 3 bits -> 24 bits in total).

Afterwards, we can parse the data for our source image and compressed JPEG image  using rmseCalculate(), which uses a normal RMSE formula.

Also added button to facilitate this in GUI end